### PR TITLE
Add second worker node group

### DIFF
--- a/clusters/waldur/configmap.yaml
+++ b/clusters/waldur/configmap.yaml
@@ -23,6 +23,9 @@ data:
       - name: group-1
         machineFlavor: vm.ska.cpu.general.small
         machineCount: 3
+      - name: group-2
+        machineFlavor: vm.ska.cpu.general.eighth
+        machineCount: 1
 
     addons:
       # Use the cilium CNI


### PR DESCRIPTION
Waldur deployment is being consistently OOM killed. Adding a second worker node for now until we can determine some suitable resource constraints to add to Waldur pods.