### PR TITLE
Add support for Intel GPU nodes to JupyterHub cluster

### DIFF
--- a/clusters/jupyterhub/configmap.yaml
+++ b/clusters/jupyterhub/configmap.yaml
@@ -14,7 +14,7 @@ data:
 
     # Give ourselves a backdoor in case we break
     # things during development and testing.
-    machineSSHKeyName: scott-key                                                                                                                                                                                                                                        │
+    machineSSHKeyName: scott-key
 
     clusterNetworking:
       externalNetworkId: 57add367-d205-4030-a929-d75617a7c63e

--- a/clusters/jupyterhub/configmap.yaml
+++ b/clusters/jupyterhub/configmap.yaml
@@ -12,6 +12,10 @@ data:
     kubernetesVersion: 1.29.5
     machineImageId: f08b688e-645a-4444-a811-c181bd82cc50 # == ubuntu-jammy-kube-v1.29.5-240605-0529
 
+    # Give ourselves a backdoor in case we break
+    # things during development and testing.
+    machineSSHKeyName: scott-key                                                                                                                                                                                                                                        │
+
     clusterNetworking:
       externalNetworkId: 57add367-d205-4030-a929-d75617a7c63e
 
@@ -26,9 +30,57 @@ data:
       machineCount: 3
 
     nodeGroups:
-      - name: group-1
+      # NOTE: Do not delete the core node group. This will
+      # ensure that CAPI and FluxCD controllers always have
+      # somewhere to run if other node groups are unavailable.
+      - name: core
         machineFlavor: vm.ska.cpu.general.small
         machineCount: 3
+      - name: gpu-pvc
+        machineFlavor: vm.rcp.1x.pvc.1t.quarter
+        machineCount: 1
+        kubeadmConfigSpec:
+
+          # Install Intel GPU drivers
+          preKubeadmCommands:
+            - |
+              # Adapted from https://dgpu-docs.intel.com/driver/installation.html#ubuntu
+              sudo apt update
+              sudo apt install -y gpg-agent wget
+
+              . /etc/os-release
+              if [[ ! " jammy " =~ " ${VERSION_CODENAME} " ]]; then
+                  echo "Ubuntu version ${VERSION_CODENAME} not supported"
+              else
+                  wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
+                  sudo gpg --yes --dearmor --output /usr/share/keyrings/intel-graphics.gpg
+                  echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu ${VERSION_CODENAME}/lts/2350 unified" | \
+                  sudo tee /etc/apt/sources.list.d/intel-gpu-${VERSION_CODENAME}.list
+                  sudo apt update
+              fi
+
+              sudo apt install -y \
+                  linux-headers-$(uname -r) \
+                  linux-modules-extra-$(uname -r) \
+                  flex bison \
+                  intel-fw-gpu intel-i915-dkms xpu-smi
+
+              # Avoids reboot
+              modprobe i915
+
+          # NOTE(scott): This might be a route to simplifying the
+          # device permissions config in for JupyterHub GPU pods,
+          # but doesn't seem to work out of the box. More work
+          # needed.
+          # Fix GPU device permissions
+          # files:
+          #   - path: /etc/containerd/conf.d/device-owners.toml
+          #     content: |
+          #       [plugins]
+          #         [plugins."io.containerd.grpc.v1.cri"]
+          #         device_ownership_from_security_context = true
+          #     owner: root:root
+          #     permissions: "0644"
 
     addons:
       # Use the cilium CNI
@@ -43,9 +95,11 @@ data:
       monitoring:
         enabled: true
 
-      # Disable NFD and the NVIDIA/Mellanox operators
+      # Required for Intel device plugin operator
       nodeFeatureDiscovery:
-        enabled: false
+        enabled: true
+
+      # Disable NVIDIA/Mellanox operators
       nvidiaGPUOperator:
         enabled: false
       mellanoxNetworkOperator:

--- a/clusters/jupyterhub/extras/kustomization.yaml
+++ b/clusters/jupyterhub/extras/kustomization.yaml
@@ -6,3 +6,4 @@
 resources:
   - ../../../components/jupyterhub
   - ../../../components/cert-manager/issuers.yaml
+  - ../../../components/spegel

--- a/clusters/jupyterhub/kustomization.yaml
+++ b/clusters/jupyterhub/kustomization.yaml
@@ -25,3 +25,5 @@ patches:
           kind: ConfigMap
           name: jupyterhub-cluster-config
           valuesKey: values.yaml
+
+# TODO: Add control plane toleration for critical Flux / CAPI deployments here?

--- a/components/intel-device-plugin/gpu-config.yaml
+++ b/components/intel-device-plugin/gpu-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: deviceplugin.intel.com/v1
+kind: GpuDevicePlugin
+metadata:
+  name: gpudeviceplugin-sample
+spec:
+  image: intel/intel-gpu-plugin:0.30.0
+  sharedDevNum: 1
+  preferredAllocationPolicy: none
+  logLevel: 4
+  enableMonitoring: true
+  nodeSelector:
+    # non-existent: used-to-remove-from-all-nodes
+    gpu.intel.com/product: Max_1550
+

--- a/components/intel-device-plugin/kustomization.yaml
+++ b/components/intel-device-plugin/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - namespace.yaml
+  - operator.yaml
+  - gpu-config.yaml

--- a/components/intel-device-plugin/namespace.yaml
+++ b/components/intel-device-plugin/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: intel

--- a/components/intel-device-plugin/operator.yaml
+++ b/components/intel-device-plugin/operator.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: intel-device-plugins-for-kubernetes
+  namespace: intel
+spec:
+  interval: 5m
+  url: https://github.com/intel/intel-device-plugins-for-kubernetes
+  ref:
+    tag: v0.30.0
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: node-feature-rules
+  namespace: intel
+spec:
+  interval: 10m
+  targetNamespace: intel
+  sourceRef:
+    kind: GitRepository
+    name: intel-device-plugins-for-kubernetes
+  path: deployments/nfd/overlays/node-feature-rules/
+  prune: true
+  timeout: 1m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: operator
+  namespace: intel
+spec:
+  interval: 10m
+  targetNamespace: intel
+  sourceRef:
+    kind: GitRepository
+    name: intel-device-plugins-for-kubernetes
+  path: deployments/operator/default
+  prune: true
+  timeout: 1m

--- a/components/jupyterhub/configmap.yaml
+++ b/components/jupyterhub/configmap.yaml
@@ -103,15 +103,25 @@ data:
                   "image": "quay.io/jupyter/datascience-notebook:2024-08-05"
                 },
               },
+              {
+                "display_name": "Pytorch environment (CPU)",
+                "description": "The official Jupyter Pytorch.",
+                "kubespawner_override": {
+                  "image": "quay.io/jupyter/pytorch-notebook:pytorch-2.4.0",
+                },
+              },
             ]
 
             config.load_incluster_config()
             api = client.CoreV1Api()
             nodes = api.list_node().items
-            has_gpu = lambda node: node.metadata.labels.get("nvidia.com/gpu.present", "") == "true"
-            if any(map(has_gpu, nodes)):
+
+            has_nvidia_gpu = lambda node: node.metadata.labels.get("nvidia.com/gpu.present", "") == "true"
+            has_intel_gpu = lambda node: node.metadata.labels.get("gpu.intel.com/device-id.0380-0bd5.present", "") == "true"
+
+            if any(map(has_nvidia_gpu, nodes)):
               profiles.append({
-                "display_name": "Pytorch environment",
+                "display_name": "Pytorch environment (Nvidia GPU)",
                 "description": "The official Jupyter Pytorch + CUDA image. Requires a GPU compatible notebook server.",
                 "kubespawner_override": {
                   "image": "quay.io/jupyter/pytorch-notebook:cuda12-pytorch-2.4.0",
@@ -120,12 +130,18 @@ data:
                   },
                 },
               })
-            else:
+            if any(map(has_intel_gpu, nodes)):
               profiles.append({
-                "display_name": "Pytorch environment",
-                "description": "The official Jupyter Pytorch.",
+                "display_name": "Pytorch environment (Intel GPU)",
+                "description": "A Jupyter + Intel Pytorch image. Requires a GPU compatible notebook server.",
                 "kubespawner_override": {
-                  "image": "quay.io/jupyter/pytorch-notebook:pytorch-2.4.0",
+                  "image": "sd327/jupyterhub-pytorch-intel-gpu:latest",
+                  "extra_resource_limits": {
+                    "gpu.intel.com/i915": "1",
+                  },
+                  "supplemental_gids":[
+                    "110", # Ubuntu render group GID, requred for permission to use Intel GPU device
+                  ],
                 },
               })
 

--- a/components/jupyterhub/configmap.yaml
+++ b/components/jupyterhub/configmap.yaml
@@ -135,7 +135,7 @@ data:
                 "display_name": "Pytorch environment (Intel GPU)",
                 "description": "A Jupyter + Intel Pytorch image. Requires a GPU compatible notebook server.",
                 "kubespawner_override": {
-                  "image": "sd327/jupyterhub-pytorch-intel-gpu:latest",
+                  "image": "ghcr.io/stackhpc/jupyterhub-pytorch-intel-gpu:v0.0.1",
                   "extra_resource_limits": {
                     "gpu.intel.com/i915": "1",
                   },

--- a/components/spegel/helmrelease.yaml
+++ b/components/spegel/helmrelease.yaml
@@ -1,0 +1,15 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: spegel
+  namespace: spegel
+spec:
+  interval: 1m
+  chart:
+    spec:
+      chart: spegel
+      version: "v0.0.23"
+      interval: 5m
+      sourceRef:
+        kind: HelmRepository
+        name: spegel

--- a/components/spegel/helmrepository.yaml
+++ b/components/spegel/helmrepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: spegel
+  namespace: spegel
+spec:
+  type: "oci"
+  interval: 5m0s
+  url: oci://ghcr.io/spegel-org/helm-charts

--- a/components/spegel/kustomization.yaml
+++ b/components/spegel/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/components/spegel/namespace.yaml
+++ b/components/spegel/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spegel


### PR DESCRIPTION
Also adds an optional [Spegel](https://github.com/spegel-org/spegel) component to try to improve image pull times for large GPU notebook images.